### PR TITLE
Get file directory for listed pages

### DIFF
--- a/lib/Convert.php
+++ b/lib/Convert.php
@@ -31,7 +31,7 @@ class Convert
             // Checking file type since only images are processed
             if ($file->type() == 'image') {
                 // WebPConvert options
-                $path = kirby()->root('content') . '/' . dirname($file->id()) . '/';
+                $path = $file->contentFileDirectory() . '/';
                 $input = $path . $file->filename();
                 $output = $path . $file->name() . '.webp';
 


### PR DESCRIPTION
`$file->id()` returns the foldername + filename but doesn't take listed pages into account. I replaced the functionality for the `$path` variable with `$file->contentFileDirectory()`. Which returns the absolute path including the right directory.