### PR TITLE
Fix issue with unsupported image type uploads, add missing functionality to remove WebP files when deleting the original files via the panel

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 @include_once __DIR__ . '/src/webp.php';
 
 function shouldGenerateWebP($file) {
-    return $file->kirby()->option('kirby3-webp', false) && $file->extension() !== 'svg';
+    return $file->kirby()->option('kirby3-webp', false);
 }
 
 function generateWebP($file) {

--- a/index.php
+++ b/index.php
@@ -6,12 +6,12 @@
 Kirby::plugin('felixhaeberle/kirby3-webp', [
     'hooks' => [
         'file.create:after' => function ($file) {
-            if ($this->option('kirby3-webp', false)) {
+            if ($this->option('kirby3-webp', false) && $file->extension() !== 'svg') {
                 (new WebP\Convert)->generateWebP($file);
             }
         },
         'file.replace:after' => function ($newFile, $oldFile) {
-            if ($this->option('kirby3-webp', false)) {
+            if ($this->option('kirby3-webp', false) && $newFile->extension() !== 'svg') {
                 (new WebP\Convert)->generateWebP($newFile);
             }
         },

--- a/index.php
+++ b/index.php
@@ -3,27 +3,41 @@
 @include_once __DIR__ . '/vendor/autoload.php';
 @include_once __DIR__ . '/src/webp.php';
 
+function shouldGenerateWebP($file) {
+    return $file->kirby()->option('kirby3-webp', false) && $file->extension() !== 'svg';
+}
+
+function generateWebP($file) {
+    (new WebP\Convert)->generateWebP($file);
+}
+
+function deleteWebPFiles($file) {
+    $webpFile = dirname($file->root()) . '/' . $file->name() . '.webp';
+    $webpTxtFile = dirname($file->root()) . '/' . $file->name() . '.webp.txt';
+    deleteIfExist($webpFile);
+    deleteIfExist($webpTxtFile);
+}
+
+function deleteIfExist($file) {
+    if (F::exists($file)) {
+        F::remove($file);
+    }
+}
+
 Kirby::plugin('felixhaeberle/kirby3-webp', [
     'hooks' => [
         'file.create:after' => function ($file) {
-            if ($this->option('kirby3-webp', false) && $file->extension() !== 'svg') {
-                (new WebP\Convert)->generateWebP($file);
+            if (shouldGenerateWebP($file)) {
+                generateWebP($file);
             }
         },
         'file.replace:after' => function ($newFile, $oldFile) {
-            if ($this->option('kirby3-webp', false) && $newFile->extension() !== 'svg') {
-                (new WebP\Convert)->generateWebP($newFile);
+            if (shouldGenerateWebP($newFile)) {
+                generateWebP($newFile);
             }
         },
         'file.delete:after' => function ($file) {
-            $webpFile = dirname($file->root()) . '/' . $file->name() . '.webp';
-            $webpTxtFile = dirname($file->root()) . '/' . $file->name() . '.webp.txt';
-            if (F::exists($webpFile)) {
-                F::remove($webpFile);
-            }
-            if (F::exists($webpTxtFile)) {
-                F::remove($webpTxtFile);
-            }
+            deleteWebPFiles($file);
         },
     ],
 ]);

--- a/index.php
+++ b/index.php
@@ -15,5 +15,15 @@ Kirby::plugin('felixhaeberle/kirby3-webp', [
                 (new WebP\Convert)->generateWebP($newFile);
             }
         },
+        'file.delete:after' => function ($file) {
+            $webpFile = dirname($file->root()) . '/' . $file->name() . '.webp';
+            $webpTxtFile = dirname($file->root()) . '/' . $file->name() . '.webp.txt';
+            if (F::exists($webpFile)) {
+                F::remove($webpFile);
+            }
+            if (F::exists($webpTxtFile)) {
+                F::remove($webpTxtFile);
+            }
+        },
     ],
 ]);

--- a/lib/Convert.php
+++ b/lib/Convert.php
@@ -29,7 +29,7 @@ class Convert
     {
         try {
             // Checking file type since only images are processed
-            if ($file->type() == 'image') {
+            if (in_array($file->extension(), ['jpg', 'jpeg', 'png'])) {
                 // WebPConvert options
                 $path = $file->contentFileDirectory() . '/';
                 $input = $path . $file->filename();


### PR DESCRIPTION
Included in this pull request:
1. Uploads of images of unsupported types are now omitted. Since only JP(E)Gs and PNGs can be converted by [rosell-dk/webp-convert](https://github.com/rosell-dk/webp-convert), this fix ensures that when uploading unsupported image formats (e.g. SVG or BMP), you will no longer get an error message because the image conversion is not even attempted. This fixes the SVG upload issue: https://github.com/felixhaeberle/kirby3-webp/issues/10
2. Extend functionality: When the original image is deleted via the panel, the plugin now removes the corresponding `.webp` and `.webp.txt` files – just as a user would expect it.
3. A bit of code refactoring to improve readability and maintainability.